### PR TITLE
Fix issue file exits in folder and need increase version number 

### DIFF
--- a/Autodesk.Aps/Libs/DataManagementUtil.cs
+++ b/Autodesk.Aps/Libs/DataManagementUtil.cs
@@ -217,6 +217,27 @@ namespace Autodesk.Aps.Libs
 
             string itemId = "";
             string versionId = "";
+            var items = await GetFolderItems(projectId, folderUrn, accessToken).ConfigureAwait(false);
+            var item = items.Cast<KeyValuePair<string, dynamic>>().FirstOrDefault(item =>
+                item.Value.attributes.displayName.Equals(filename, StringComparison.OrdinalIgnoreCase));
+            FileInfoInDocs fileInfo;
+            if (item.Value != null)
+            {
+                //Get ItemId of our file
+                itemId = item.Value.id;
+
+                //Lets create a new version
+                versionId = await UpdateVersionAsync(projectId, itemId, objectId, filename, accessToken).ConfigureAwait(false);
+
+                fileInfo = new FileInfoInDocs
+                {
+                    ProjectId = projectId,
+                    FolderUrn = folderUrn,
+                    ItemId = itemId,
+                    VersionId = versionId
+                };
+                return fileInfo;
+            }
             try
             {
                 DynamicJsonResponse postItemJsonResponse = await itemsApi.PostItemAsync(projectId, itemBody);
@@ -252,7 +273,7 @@ namespace Autodesk.Aps.Libs
                 throw new InvalidOperationException("Failed to Create/Append file version");
             }
 
-            var fileInfo = new FileInfoInDocs
+            fileInfo = new FileInfoInDocs
             {
                 ProjectId = projectId,
                 FolderUrn = folderUrn,


### PR DESCRIPTION
I'm just try catch small code 
Let's say I have a file model.rvt exits at the first time upload and then when I'm run for the second time, it should be allow increase  new version 👍 
![image](https://github.com/yiskang/aps-utility-service-dotnet/assets/31106432/f5898f82-bacd-4930-92e4-30ec598f6f44)
https://aps.autodesk.com/en/docs/bim360/v1/tutorials/document-management/upload-document-s3/